### PR TITLE
Add .babelrc to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10-alpine
 EXPOSE 8000
 WORKDIR /opt/app
 
-COPY package.json yarn.lock ./
+COPY package.json yarn.lock .babelrc ./
 RUN yarn
 COPY src src
 RUN yarn build


### PR DESCRIPTION
Otherwise `yarn build` won't actually translate our imports/exports.