### PR TITLE
[Breaking] Today/Upcoming Meetings

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "lint-staged": {
     "*.{js,jsx}": [
-      "prettier",
+      "prettier --write",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "express-async-errors": "^3.1.1",
+    "moment": "^2.24.0",
     "mongodb": "^2.2.16",
     "mongoose": "^5.3.13",
     "morgan": "^1.9.1"

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -16,8 +16,18 @@ const connect = async ({ url }) => {
   };
 };
 
+// --- Helpers
+const rangeToday = clock => ({
+  $gte: clock.today(),
+  $lt: clock.endOfToday(),
+});
+
+const rangeUpcoming = clock => ({
+  $gte: clock.today(),
+});
+
 // --- Database Operations
-const Meeting = {
+const Meeting = clock => ({
   clear: () => MeetingModel.remove({}),
   create: data => new MeetingModel(data).save(),
   delete: async id => {
@@ -27,14 +37,16 @@ const Meeting = {
     }
   },
   list: () => MeetingModel.find(),
-};
+  listToday: () => MeetingModel.find({ date: rangeToday(clock) }),
+  listUpcoming: () => MeetingModel.find({ date: rangeUpcoming(clock) }),
+});
 
 // --- Database Facade
-export default async config => {
+export default async (config, clock) => {
   const database = await connect(config);
 
   return {
     ...database,
-    Meeting,
+    Meeting: Meeting(clock),
   };
 };

--- a/src/db/models/meeting.js
+++ b/src/db/models/meeting.js
@@ -5,7 +5,7 @@ const MeetingSchema = mongoose.Schema(
     host: String,
     phone: String,
     meeting: String,
-    date: String,
+    date: Date,
   },
   {
     timestamps: true,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
 import config from './config';
 import server from './server';
+import system from './system';
 
-server(config)
+const run = async config => {
+  const sys = await system(config);
+
+server(config, sys)
   .then(({ port }) => {
     console.log(`🚀  We are live on port ${port}!`);
   })
@@ -9,3 +13,6 @@ server(config)
     console.error(`💥 Startup failed with exception!`, e);
     process.exit(1);
   });
+};
+
+run(config);

--- a/src/routes/meetings.js
+++ b/src/routes/meetings.js
@@ -1,5 +1,4 @@
 export default (app, { database: { Meeting } }) => {
-
   app.post('/meetings', async (req, res) => {
     const { host, meeting, phone, date } = req.body;
 
@@ -18,6 +17,16 @@ export default (app, { database: { Meeting } }) => {
     res.send(meetings);
   });
 
+  app.get('/meetings/q/today', async (_, res) => {
+    const meetings = await Meeting.listToday();
+    res.send(meetings);
+  });
+
+  app.get('/meetings/q/upcoming', async (_, res) => {
+    const meetings = await Meeting.listUpcoming();
+    res.send(meetings);
+  });
+
   app.delete('/meetings/:id', async (req, res) => {
     const { id } = req.params;
     await Meeting.delete(id);
@@ -29,5 +38,4 @@ export default (app, { database: { Meeting } }) => {
     await Meeting.clear();
     res.send({ message: 'All meetings deleted' });
   });
-
 };

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,6 @@ import express from 'express';
 import 'express-async-errors';
 import morgan from 'morgan';
 
-import connectDb from './db';
 import addRoutes from './routes';
 
 const errorLogger = (err, req, res, _next) => {
@@ -17,11 +16,7 @@ const shutdown = async (server, { database }) => {
   await database.shutdown();
 }
 
-export default async ({ development, port, db }) => {
-  // --- Infrastructure
-  const database = await connectDb(db);
-  const system = { database };
-
+export default async ({ development, port }, system) => {
   // --- Server
   const app = express();
   app.use(morgan(development ? 'dev' : 'combined'));

--- a/src/system/clock.js
+++ b/src/system/clock.js
@@ -1,0 +1,6 @@
+import moment from 'moment';
+
+export default ()=> ({
+  today: () => moment().startOf('day').toDate(),
+  endOfToday: () => moment().endOf('day').toDate(),
+});

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -1,0 +1,9 @@
+import clock from './clock';
+import connectDb from '../db';
+
+export default async ({ db }) => {
+  const clockInst = clock();
+  const database = await connectDb(db, clockInst);
+
+  return { clock, database };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2421,6 +2421,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 mongodb-core@2.1.20:
   version "2.1.20"
   resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-2.1.20.tgz#fece8dd76b59ee7d7f2d313b65322c160492d8f1"


### PR DESCRIPTION
This is breaking due to the type change in the Meeting model. Records that have been added previously will not show up in the filtered lists since the query won't be able to find them.

Also, this needs a change to the frontend since we're now delivering an actual ISO-8601 date and the display logic show's them with the `.000Z` suffix.

The reason the clock is a separate object is that it will be way easier to test our core logic if we have control over the time.