### PR TITLE
Introduce offices

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -46,12 +46,17 @@ const Meeting = ({ office }, clock) => {
       }
     },
 
-    list: () => MeetingModel.find(filters),
+    list: () => MeetingModel.find(filters).sort({ date: 1 }),
 
-    listToday: () => MeetingModel.find({ date: rangeToday(clock), ...filters }),
+    listToday: () =>
+      MeetingModel.find({ date: rangeToday(clock), ...filters }).sort({
+        date: 1,
+      }),
 
     listUpcoming: () =>
-      MeetingModel.find({ date: rangeUpcoming(clock), ...filters }),
+      MeetingModel.find({ date: rangeUpcoming(clock), ...filters }).sort({
+        date: 1,
+      }),
   };
 };
 

--- a/src/db/models/meeting.js
+++ b/src/db/models/meeting.js
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 
 const MeetingSchema = mongoose.Schema(
   {
+    office: String,
     host: String,
     phone: String,
     meeting: String,

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,5 +1,11 @@
-export default app => {
-  app.get("/health", (_, res) => {
-    res.status(200).send({ status: "OK" });
+import { Router } from 'express';
+
+export default () => {
+  const app = new Router();
+
+  app.get('/health', (_, res) => {
+    res.status(200).send({ status: 'OK' });
   });
+
+  return app;
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,7 +14,7 @@ const withContext = (defaults = {}) => (req, _, next) => {
 };
 
 const withSystem = system => (req, _, next) => {
-  req.system = system;
+  req.system = system(req.systemContext);
   next();
 };
 
@@ -25,9 +25,10 @@ export default (app, system) => {
   const health = healthRoutes();
 
   // Legacy Routes
+  // FIXME: remove after clients have migrated
   app.use(withContext({ office: 'munich' }), withSystem(system), meetings);
 
   // Routes
-  app.use('/:office/*', withContext(), withSystem(system), meetings);
+  app.use('/:office', withContext(), withSystem(system), meetings);
   app.use(health);
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,7 +1,15 @@
+import { Router } from 'express';
+
 import meetingRoutes from './meetings';
 import healthRoutes from './health';
 
 export default (app, system) => {
-  meetingRoutes(app, system);
+  // --- General Routes
+  meetingRoutes(app, system); // Remove once no longer needed
   healthRoutes(app);
+
+  // --- Office Routes
+  const office = new Router();
+  meetingRoutes(office, system);
+  app.use('/:office', office);
 };

--- a/src/routes/meetings.js
+++ b/src/routes/meetings.js
@@ -1,4 +1,9 @@
-export default (app, { database: { Meeting } }) => {
+import { Router } from 'express';
+
+export default () => {
+  const app = new Router();
+  const Meeting = req => req.system.database.Meeting;
+
   app.post('/meetings', async (req, res) => {
     const { host, meeting, phone, date } = req.body;
 
@@ -8,34 +13,36 @@ export default (app, { database: { Meeting } }) => {
       });
     }
 
-    const created = await Meeting.create({ host, meeting, phone, date });
+    const created = await Meeting(req).create({ host, meeting, phone, date });
     res.send(created);
   });
 
-  app.get('/meetings', async (_, res) => {
-    const meetings = await Meeting.list();
+  app.get('/meetings', async (req, res) => {
+    const meetings = await Meeting(req).list();
     res.send(meetings);
   });
 
-  app.get('/meetings/q/today', async (_, res) => {
-    const meetings = await Meeting.listToday();
+  app.get('/meetings/q/today', async (req, res) => {
+    const meetings = await Meeting(req).listToday();
     res.send(meetings);
   });
 
-  app.get('/meetings/q/upcoming', async (_, res) => {
-    const meetings = await Meeting.listUpcoming();
+  app.get('/meetings/q/upcoming', async (req, res) => {
+    const meetings = await Meeting(req).listUpcoming();
     res.send(meetings);
   });
 
   app.delete('/meetings/:id', async (req, res) => {
     const { id } = req.params;
-    await Meeting.delete(id);
+    await Meeting(req).delete(id);
     res.send({ message: 'Meeting deleted successfully!' });
   });
 
   //todo remove after dev finished
-  app.delete('/meetings/', async (_, res) => {
-    await Meeting.clear();
+  app.delete('/meetings/', async (req, res) => {
+    await Meeting(req).clear();
     res.send({ message: 'All meetings deleted' });
   });
+
+  return app;
 };

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -5,5 +5,5 @@ export default async ({ db }) => {
   const clockInst = clock();
   const database = await connectDb(db, clockInst);
 
-  return { clock, database };
+  return context => ({ clock: clockInst, database: database(context) });
 };


### PR DESCRIPTION
This will add a `/:office` prefix to routes. (Existing routes will default to `"munich"`.)

Some decisions I made:

- Instead of passing `office` to every method, we recreate the system on every request (just the wrappers, not the database connections) and pass the `office` to the constructor functions.
- Instead of passing the system directly to routes, we now inject it into the request using a middleware.
- Instead of passing `app` to the route functions, we let them create an `express.Router` and attach that to `app`. (This allows us to use the same router for the old routes and the new ones with office prefix.)

Additionally, this PR fixes sorting of meetings.